### PR TITLE
Introduce falcon-node-sensor build to the tools image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,9 +19,10 @@ COPY --from=builder /root/go/bin/docker-credential-ecr-login /root/go/bin/falcon
 COPY .docker /root/.docker
 COPY demo-yamls /root/demo-yamls
 COPY kubernetes.repo google-cloud-sdk.repo /etc/yum.repos.d/
+COPY falcon-node-sensor-build /bin
 
 RUN : \
-    && dnf install -y kubectl groff-base bash-completion google-cloud-sdk tmux \
+    && dnf install -y kubectl groff-base bash-completion google-cloud-sdk tmux git \
     && curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
     && dnf install -y zip \
     && unzip awscliv2.zip \

--- a/falcon-node-sensor-build
+++ b/falcon-node-sensor-build
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+set -e -o pipefail
+
+function die(){
+    echo "$0: fatal error: $*" >&2
+    exit 1
+}
+
+if [ -z "$FALCON_CLIENT_ID" ]; then
+    die "Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+fi
+if [ -z "$FALCON_CLIENT_SECRET" ]; then
+    die "Missing FALCON_CLIENT_SECRET environment variable. Please provide your OAuth2 API Client Secret for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+fi
+
+tempdir=$(mktemp -d)
+tempdir_cleanup() { rm -rf "$tempdir"; }; trap tempdir_cleanup EXIT
+
+pushd "$tempdir"
+git clone --depth 1 https://github.com/CrowdStrike/Dockerfiles
+pushd Dockerfiles
+
+case "$1" in
+    ubuntu20)
+        falcon_sensor_download --os-name=Ubuntu --os-version=14/16/18/20
+        docker build --no-cache=true \
+               --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+               --build-arg VCS_REF="$(git rev-parse --short HEAD)" \
+               --build-arg FALCON_PKG=falcon-sensor_*_amd64.deb \
+               -t falcon-node-sensor:latest \
+               -f Dockerfile.ubuntu .
+        ;;
+    rhel8)
+        falcon_sensor_download --os-name=RHEL/CentOS/Oracle --os-version=8
+        docker build --no-cache=true \
+               --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+               --build-arg VCS_REF="$(git rev-parse --short HEAD)" \
+               --build-arg FALCON_PKG=falcon-sensor-*.x86_64.rpm \
+               -t falcon-node-sensor:latest \
+               -f Dockerfile .
+        ;;
+    sles15)
+        falcon_sensor_download --os-name=SLES --os-version=15
+        docker build --no-cache=true \
+               --build-arg BUILD_DATE="$(date -u +'%Y-%m-%dT%H:%M:%SZ')" \
+               --build-arg VCS_REF="$(git rev-parse --short HEAD)" \
+               --build-arg FALCON_PKG=falcon-sensor-*.rpm \
+               -t falcon-node-sensor:latest \
+               -f Dockerfile.suse .
+        ;;
+    *)
+        die "Please provide node operating system as command-line argument. Valid options are: ubuntu20, rhel8, sles15"
+        ;;
+esac
+
+docker images falcon-node-sensor
+
+echo "Contaner falcon-node-sensor:latest has been built successfully"
+


### PR DESCRIPTION
This simple script builds falcon-node-sensor used by daemonset or helm chart,
provides sane defaults and successful patters to the image build.