### PR TITLE
update node sensor tooling & update to centos8stream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.centos.org/centos/centos:8 as builder
+FROM quay.io/centos/centos:stream8 as builder
 
 RUN dnf install -y unzip golang-bin git
 
@@ -17,7 +17,7 @@ RUN curl -sS https://webinstall.dev/k9s | bash
 RUN go get -u github.com/crowdstrike/gofalcon/examples/falcon_sensor_download github.com/crowdstrike/gofalcon/examples/falcon_registry_token github.com/crowdstrike/gofalcon/examples/falcon_get_cid
 
 
-FROM registry.centos.org/centos/centos:8
+FROM quay.io/centos/centos:stream8
 
 COPY --from=builder /tmp/eksctl /usr/local/bin/helm /bin/
 COPY --from=builder /root/go/bin/docker-credential-ecr-login /root/go/bin/falcon_* /bin/
@@ -25,7 +25,7 @@ COPY --from=builder /root/.local/bin/k9s /bin/
 COPY .docker /root/.docker
 COPY demo-yamls /root/demo-yamls
 COPY kubernetes.repo google-cloud-sdk.repo azure-cli.repo /etc/yum.repos.d/
-COPY falcon-node-sensor-build falcon-container-sensor-push falcon-image-pull-token /bin/
+COPY falcon-node-sensor-build falcon-node-sensor-push falcon-container-sensor-push falcon-image-pull-token /bin/
 
 RUN : \
     && dnf update -y \

--- a/README.md
+++ b/README.md
@@ -18,8 +18,10 @@ Cloud-tools-image is a collection of command-line tools for remote communication
 Cloud-tools-image is an open source project, not a CrowdStrike product. As such it carries no formal support, expressed or implied.
 
 This container contains following command-line tools:
- * falcon_sensor_download command
- * falcon-node-sensor-build command
+ * falcon-image-pull-token command
+ * falcon-container-sensor-push command
+ * falcon-node-sensor-push command
+ * falcon-node-sensor-build command (deprecated)
  * aws command
  * eksctl command
  * kubectl command

--- a/falcon-node-sensor-push
+++ b/falcon-node-sensor-push
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+: <<'#OutsideUsageExample'
+
+docker run --privileged=true -it --rm \
+        -e FALCON_CLIENT_ID="$FALCON_CLIENT_ID" \
+        -e FALCON_CLIENT_SECRET="$FALCON_CLIENT_SECRET" \
+        -e FALCON_CLOUD="$FALCON_CLOUD" \
+        -v /var/run/docker.sock:/var/run/docker.sock \
+        -v ~/.config/gcloud:/root/.config/gcloud \
+        quay.io/crowdstrike/cloud-tools-image \
+        bash -xc "gcloud auth configure-docker ; falcon-node-sensor-push gcr.io/my-project/falcon-node-sensor "
+
+#OutsideUsageExample
+
+
+
+set -e -o pipefail
+
+function die(){
+    echo "$0: fatal error: $*" >&2
+    exit 1
+}
+
+if [ -z "$FALCON_CLOUD" ]; then
+    echo "WARNING: FALCON_CLOUD environment variable missing. Assuming FALCON_CLOUD=us-1" >&2
+fi
+
+if [ -z "$FALCON_CLIENT_ID" ]; then
+    die "Missing FALCON_CLIENT_ID environment variable. Please provide your OAuth2 API Client ID for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+fi
+if [ -z "$FALCON_CLIENT_SECRET" ]; then
+    die "Missing FALCON_CLIENT_SECRET environment variable. Please provide your OAuth2 API Client Secret for authentication with CrowdStrike Falcon platform. Establishing and retrieving OAuth2 API credentials can be performed at https://falcon.crowdstrike.com/support/api-clients-and-keys."
+fi
+
+case "$FALCON_CLOUD" in
+    ""|"us-1")
+        CLOUD_LOWER=us-1
+        ;;
+    "us-2")
+        CLOUD_LOWER=us-2
+        ;;
+    "eu-1")
+        CLOUD_LOWER=eu-1
+        ;;
+    "*")
+        die "Invalid cloud specifier in FALCON_CLOUD environment variable: $FALCON_CLOUD"
+        ;;
+esac
+
+if [ -z "$CID" ]; then
+    CID=$(falcon_get_cid)
+fi
+
+if [ -z "$1" ]; then
+    die "Missing command-line argument destination URI. Please provide your registry location for pushing the sensor"
+fi
+DESTINATION_IMAGE="$1"
+
+falcon_registry_token | skopeo login --username $(echo "$CID" | awk -F-  '{print("fc-" tolower($1))}') --password-stdin registry.crowdstrike.com
+SOURCE_IMAGE="registry.crowdstrike.com/falcon-sensor/$CLOUD_LOWER/release/falcon-sensor"
+SOURCE_TAG=$(skopeo list-tags docker://$SOURCE_IMAGE | jq -r '.Tags[-1]')
+
+target1=$DESTINATION_IMAGE:$SOURCE_TAG
+target2=$DESTINATION_IMAGE:latest
+
+skopeo copy docker://"$SOURCE_IMAGE:$SOURCE_TAG" "docker-daemon:$target1"
+docker push "$target1"
+docker tag "$target1" "$target2"
+docker push "$target2"


### PR DESCRIPTION
Centos8 is EOL, moved to Centos8Stream which is supported till 2024 and is available from quay.io.

Added new binary for pulling down node sensor builds and set a deprecated item in the readme for the node sensor build process. Opted for new binary instead of providing additional args to container pull incase this is being used in some automated fashion.